### PR TITLE
Fix use of jsonargparse avoiding reliance on non-public internal logic

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ torchmetrics >0.7.0, <0.11.0  # strict
 pytorch-lightning >1.8.0, <2.0.0  # strict
 pyDeprecate >0.2.0
 pandas >1.1.0, <=1.5.2
-jsonargparse[signatures] >4.0.0, <=4.9.0
+jsonargparse[signatures] >=4.22.0, <4.23.0
 click >=7.1.2, <=8.1.3
 protobuf <=3.20.1
 fsspec[http] >=2022.5.0,<=2023.6.0

--- a/tests/core/utilities/test_lightning_cli.py
+++ b/tests/core/utilities/test_lightning_cli.py
@@ -40,7 +40,7 @@ def test_default_args(mock_argparse, tmpdir):
     """Tests default argument parser for Trainer."""
     mock_argparse.return_value = Namespace(**Trainer.default_attributes())
 
-    parser = LightningArgumentParser(add_help=False, parse_as_dict=False)
+    parser = LightningArgumentParser(add_help=False)
     args = parser.parse_args([])
 
     args.max_epochs = 5
@@ -54,7 +54,7 @@ def test_default_args(mock_argparse, tmpdir):
 @pytest.mark.parametrize("cli_args", [["--accumulate_grad_batches=22"], ["--default_root_dir=./"], []])
 def test_add_argparse_args_redefined(cli_args):
     """Redefines some default Trainer arguments via the cli and tests the Trainer initialization correctness."""
-    parser = LightningArgumentParser(add_help=False, parse_as_dict=False)
+    parser = LightningArgumentParser(add_help=False)
     parser.add_lightning_class_args(Trainer, None)
 
     args = parser.parse_args(cli_args)
@@ -79,11 +79,11 @@ def test_add_argparse_args_redefined(cli_args):
         ("--auto_lr_find=True --auto_scale_batch_size=power", {"auto_lr_find": True, "auto_scale_batch_size": "power"}),
         (
             "--auto_lr_find any_string --auto_scale_batch_size ON",
-            {"auto_lr_find": "any_string", "auto_scale_batch_size": True},
+            {"auto_lr_find": "any_string", "auto_scale_batch_size": "ON"},
         ),
-        ("--auto_lr_find=Yes --auto_scale_batch_size=On", {"auto_lr_find": True, "auto_scale_batch_size": True}),
-        ("--auto_lr_find Off --auto_scale_batch_size No", {"auto_lr_find": False, "auto_scale_batch_size": False}),
-        ("--auto_lr_find TRUE --auto_scale_batch_size FALSE", {"auto_lr_find": True, "auto_scale_batch_size": False}),
+        ("--auto_lr_find=Yes --auto_scale_batch_size=On", {"auto_lr_find": True, "auto_scale_batch_size": "On"}),
+        ("--auto_lr_find Off --auto_scale_batch_size No", {"auto_lr_find": False, "auto_scale_batch_size": "No"}),
+        ("--auto_lr_find TRUE --auto_scale_batch_size FALSE", {"auto_lr_find": True, "auto_scale_batch_size": "FALSE"}),
         ("--limit_train_batches=100", {"limit_train_batches": 100}),
         ("--limit_train_batches 0.8", {"limit_train_batches": 0.8}),
     ],
@@ -91,7 +91,7 @@ def test_add_argparse_args_redefined(cli_args):
 def test_parse_args_parsing(cli_args, expected):
     """Test parsing simple types and None optionals not modified."""
     cli_args = cli_args.split(" ") if cli_args else []
-    parser = LightningArgumentParser(add_help=False, parse_as_dict=False)
+    parser = LightningArgumentParser(add_help=False)
     parser.add_lightning_class_args(Trainer, None)
     with patch("sys.argv", ["any.py"] + cli_args):
         args = parser.parse_args()
@@ -112,7 +112,7 @@ def test_parse_args_parsing(cli_args, expected):
 )
 def test_parse_args_parsing_complex_types(cli_args, expected, instantiate):
     """Test parsing complex types."""
-    parser = LightningArgumentParser(add_help=False, parse_as_dict=False)
+    parser = LightningArgumentParser(add_help=False)
     parser.add_lightning_class_args(Trainer, None)
     with patch("sys.argv", ["any.py"] + cli_args):
         args = parser.parse_args()
@@ -137,7 +137,7 @@ def test_parse_args_parsing_gpus(mocker, cli_args, expected_gpu):
     """Test parsing of gpus and instantiation of Trainer."""
     mocker.patch("lightning_lite.utilities.device_parser._get_all_available_gpus", return_value=[0, 1])
     cli_args = cli_args.split(" ") if cli_args else []
-    parser = LightningArgumentParser(add_help=False, parse_as_dict=False)
+    parser = LightningArgumentParser(add_help=False)
     parser.add_lightning_class_args(Trainer, None)
     with patch("sys.argv", ["any.py"] + cli_args):
         args = parser.parse_args()
@@ -310,8 +310,8 @@ def test_lightning_cli_args(tmpdir):
         config = yaml.safe_load(f.read())
     assert "model" not in config
     assert "model" not in cli.config
-    assert config["data"] == cli.config["data"]
-    assert config["trainer"] == cli.config["trainer"]
+    assert config["data"] == cli.config["data"].as_dict()
+    assert config["trainer"] == cli.config["trainer"].as_dict()
 
 
 @pytest.mark.skipif(not _TOPIC_CORE_AVAILABLE, reason="Not testing core.")
@@ -363,9 +363,9 @@ def test_lightning_cli_config_and_subclass_mode(tmpdir):
     assert os.path.isfile(config_path)
     with open(config_path) as f:
         config = yaml.safe_load(f.read())
-    assert config["model"] == cli.config["model"]
-    assert config["data"] == cli.config["data"]
-    assert config["trainer"] == cli.config["trainer"]
+    assert config["model"] == cli.config["model"].as_dict()
+    assert config["data"] == cli.config["data"].as_dict()
+    assert config["trainer"] == cli.config["trainer"].as_dict()
 
 
 def any_model_any_data_cli():


### PR DESCRIPTION
## What does this PR do?

Fixes issues identified in #1564. More generally, this pull request changes `flash_cli.py` and `lightning_cli.py` such that they only use jsonargparse's public API.

closes #1564

## Before submitting
- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the **[contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md)**, Pull Request section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes?
- [x] Did you write any **new necessary tests**? [not needed for typos/docs]
- [x] Did you verify **new and existing tests pass** locally with your changes?
- [ ] If you made a notable change (that affects users), did you **update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)**?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request **ready for review**? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
